### PR TITLE
README.md update URLs and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
-zfs-stats
-=============
+# zfs-stats
 
 ZFS statistics tool for FreeBSD.
 
-The zfs-stats script displays general ZFS information
-and human-readable ZFS statistics of the following subsystems:
+The `zfs-stats` script displays general ZFS information
+and human-readable statistics for the following subsystems:
 
 * ARC
 * L2ARC
 * DMU (zfetch)
-* vdev cache
+* vdev cache.
 
-The script is a fork of Jason J. Hellenthals' [arc_summary.pl][1]
+Help: `zfs-stats -h`
 
-Availability in FreeBSD ports tree: [sysutils/zfs-stats][2]
+In the ports tree: [sysutils/zfs-stats][1]
 
-Homepage: http://www.vx.sk/zfs-stats
+Homepage: https://www.vx.sk/zfs-stats/
 
-[1]: http://code.google.com/p/jhell/
-[2]: http://www.freebsd.org/cgi/cvsweb.cgi/ports/sysutils/zfs-stats/
+This script is a fork of [arc_summary.pl][2] by Jason Hellenthal.
+
+[1]: https://www.freshports.org/sysutils/zfs-stats/
+[2]: https://github.com/DataIX/main/tree/master/head/scripts/zfs/arc_summary


### PR DESCRIPTION
<http://code.google.com/p/jhell/> redirects to <https://github.com/dataix/>, then `arc_summary.pl` is found under <https://github.com/DataIX/main/tree/master/head/scripts/zfs/arc_summary>.

A more orthodox URL for the FreshPorts page. 

Is HTTPS <https://www.vx.sk/zfs-stats/> as good as HTTP <http://www.vx.sk/zfs-stats>?

Hellenthal presents himself as _Jason Hellenthal_ – without the _J_ – at <https://www.linkedin.com/in/jhellenthal> and elsewhere. 

Parallel to this pull request, we'll benefit from a corresponding update in the FreeBSD area; for changes to appear under <https://www.freshports.org/sysutils/zfs-stats#description>. <https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=258238>

Thank you!